### PR TITLE
Update current work with the new xarray dataset interface

### DIFF
--- a/phylokit/__init__.py
+++ b/phylokit/__init__.py
@@ -6,9 +6,17 @@ from .convert import from_newick  # NOQA
 from .convert import from_tskit  # NOQA
 from .convert import to_newick  # NOQA
 from .convert import to_tskit  # NOQA
-from .distance import branch_length
 from .distance import kc_distance
 from .distance import mrca
+from .traversal import _postorder
+from .traversal import _preorder
+from .traversal import postorder
+from .traversal import preorder
+from .util import _get_node_branch_length
+from .util import check_node_bounds
+from .util import get_node_branch_length
+from .util import get_num_roots
+from .util import is_unary
 
 __all__ = [
     "sackin_index",
@@ -22,4 +30,13 @@ __all__ = [
     "mrca",
     "branch_length",
     "kc_distance",
+    "postorder",
+    "preorder",
+    "_preorder",
+    "_postorder",
+    "is_unary",
+    "get_num_roots",
+    "get_node_branch_length",
+    "_get_node_branch_length",
+    "check_node_bounds",
 ]

--- a/phylokit/traversal.py
+++ b/phylokit/traversal.py
@@ -1,0 +1,120 @@
+import numpy as np
+
+from . import core
+
+
+@core.numba_njit
+def _postorder(left_child, right_sib, root):
+    # Another implementation with python stack operations such as `pop`
+    # makes the same function about 2X slower.
+    root = root if root is not None else -1
+    num_nodes = len(left_child) - 1
+    ret = np.zeros(num_nodes, dtype=np.int32)
+    stack = np.zeros(num_nodes, dtype=np.int32)
+    stack_top = 0
+    num_roots = 0
+    count_node = 0
+    if root == -1:
+        stack_top = -1
+        v = left_child[root]
+        while v != -1:
+            num_roots += 1
+            stack_top += 1
+            stack[stack_top] = v
+            v = right_sib[v]
+    else:
+        if root < 0 or root > num_nodes:
+            return ret
+        stack_top = 0
+        stack[stack_top] = root
+
+    while stack_top >= 0:
+        u = stack[stack_top]
+        stack_top -= 1
+        ret[num_nodes - 1] = u
+        num_nodes -= 1
+        count_node += 1
+        v = left_child[u]
+        while v != -1:
+            stack_top += 1
+            stack[stack_top] = v
+            v = right_sib[v]
+
+    return ret[-count_node:]
+
+
+def postorder(ds, root=None):
+    """
+    Returns the postorder traversal of the tree.
+
+    :param xarray.DataSet ds: The tree dataset to compute the postorder traversal of.
+    :param int root: The root node to start the traversal from.
+    :return : The postorder traversal of the tree.
+    :rtype : numpy.ndarray
+    """
+    return _postorder(
+        ds.node_left_child.data,
+        ds.node_right_sib.data,
+        root,
+    )
+
+
+@core.numba_njit
+def _preorder(parent, left_child, right_sib, root):
+    # Another implementation with python stack operations such as `pop`
+    # makes the same function about 2X slower.
+    root = root if root is not None else -1
+    num_nodes = len(left_child) - 1
+    ret = np.zeros(num_nodes, dtype=np.int32)
+    stack = np.zeros(num_nodes, dtype=np.int32)
+    stack_top = 0
+    num_roots = 0
+    count_node = 0
+    if root == -1:
+        stack_top = -1
+        u = left_child[root]
+        while u != -1:
+            num_roots += 1
+            stack_top += 1
+            stack[stack_top] = u
+            u = right_sib[u]
+    else:
+        if root < 0 or root > num_nodes:
+            return ret
+        stack_top = 0
+        stack[stack_top] = root
+
+    preorder_parent = -1
+    while stack_top >= 0:
+        u = stack[stack_top]
+        if left_child[u] != -1 and u != preorder_parent:
+            v = left_child[u]
+            while v != -1:
+                stack_top += 1
+                stack[stack_top] = v
+                v = right_sib[v]
+        else:
+            stack_top -= 1
+            preorder_parent = parent[u]
+            ret[num_nodes - 1] = u
+            count_node += 1
+            num_nodes -= 1
+
+    return ret[-count_node:]
+
+
+def preorder(ds, root=None):
+    """
+    Returns the preorder traversal of the tree.
+
+    :param xarray.DataSet ds: The tree dataset to compute the preorder traversal of.
+    :param int root: The root node to start the traversal from.
+    :return : The preorder traversal of the tree.
+    :rtype : numpy.ndarray
+    """
+    return _preorder(
+        ds.node_parent.data,
+        ds.node_left_child.data,
+        ds.node_right_sib.data,
+        root,
+    )

--- a/phylokit/util.py
+++ b/phylokit/util.py
@@ -1,0 +1,105 @@
+import numpy as np
+
+from . import core
+
+
+@core.numba_njit
+def _is_unary(postorder, left_child, right_sib):
+    for u in postorder:
+        v = left_child[u]
+        num_children = 0
+        while v != -1:
+            num_children += 1
+            v = right_sib[v]
+        if num_children == 1:
+            return True
+
+
+def is_unary(ds):
+    """
+    Returns whether any of the nodes has unary number of children.
+
+    :param xarray.DataSet ds: The tree dataset to check.
+    :return : Whether the tree is unary.
+    :rtype : bool
+    """
+    return _is_unary(
+        ds.traversal_postorder.data, ds.node_left_child.data, ds.node_right_sib.data
+    )
+
+
+def check_node_bounds(ds, *args):
+    """
+    Checks that the specified node is within the tree.
+
+    :param xarray.DataArray ds: The tree to check.
+    :param int `*args`: The node IDs to check.
+    :raises ValueError: If any of the nodes are outside the tree.
+    """
+    num_nodes = ds.node_parent.data.shape[0] - 1
+    for u in args:
+        if u < 0 or u > num_nodes:
+            raise ValueError(f"Node {u} is not in the tree")
+
+
+@core.numba_njit
+def _get_num_roots(left_child, right_sib):
+    u = left_child[-1]
+    num_roots = 0
+    while u != -1:
+        num_roots += 1
+        u = right_sib[u]
+    return num_roots
+
+
+def get_num_roots(ds):
+    """
+    Returns the number of roots in the tree.
+
+    :pram xarray.DataSet ds: The tree dataset.
+    :return : The number of roots.
+    :rtype : int
+    """
+    return _get_num_roots(ds.node_left_child.data, ds.node_right_sib.data)
+
+
+@core.numba_njit
+def _branch_length(parent, time, u):
+    ret = 0
+    p = parent[u]
+    if p != -1:
+        ret = time[p] - time[u]
+    return ret
+
+
+def branch_length(ds, u):
+    """
+    Returns the length of the branch (in units of time) joining the specified
+    node to its parent.
+
+    :param xarray.DataSet ds: The tree dataset.
+    :param int u: The node ID.
+    :return : The length of the branch.
+    :rtype : float
+    """
+    check_node_bounds(ds, u)
+    return _branch_length(ds.node_parent.data, ds.node_time.data, u)
+
+
+@core.numba_njit
+def _get_node_branch_length(parent, time):
+    ret = np.zeros_like(parent)
+    for i in range(parent.shape[0]):
+        ret[i] = _branch_length(parent, time, i)
+    return ret
+
+
+def get_node_branch_length(ds):
+    """
+    Returns the branch length of each node in the tree.
+
+    :param xarray.DataSet ds: The tree dataset.
+    :return: The branch length of each node.
+    :rtype: numpy.ndarray
+    """
+    return _get_node_branch_length(ds.node_parent.data, ds.node_time.data)

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -12,8 +12,12 @@ class TestBalancedBinaryOdd:
     #     ┊ ┃ ┏┻┓ ┊
     # 0.00┊ 0 1 2 ┊
     #     0      1
-    def tree(self):
+
+    def tsk_tree(self):
         return tskit.Tree.generate_balanced(3)
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 5
@@ -35,8 +39,12 @@ class TestBalancedBinaryEven:
     #     ┊ ┏┻┓ ┏┻┓ ┊
     # 0.00┊ 0 1 2 3 ┊
     #     0         1
-    def tree(self):
+
+    def tsk_tree(self):
         return tskit.Tree.generate_balanced(4)
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 8
@@ -83,8 +91,11 @@ class TestBalancedTernary:
     #     ┊ ┏━╋━┓ ┏━╋━┓ ┏━╋━┓ ┊
     # 0.00┊ 0 1 2 3 4 5 6 7 8 ┊
     #     0                   1
-    def tree(self):
+    def tsk_tree(self):
         return tskit.Tree.generate_balanced(9, arity=3)
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 18
@@ -105,8 +116,11 @@ class TestStarN10:
     #     ┊ ┏━┳━┳━┳━┳┻┳━┳━┳━┳━┓ ┊
     # 0.00┊ 0 1 2 3 4 5 6 7 8 9 ┊
     #     0                     1
-    def tree(self):
+    def tsk_tree(self):
         return tskit.Tree.generate_star(10)
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 10
@@ -133,8 +147,11 @@ class TestCombN5:
     #     ┊ ┃ ┃ ┃ ┏┻┓ ┊
     # 0.00┊ 0 1 2 3 4 ┊
     #     0           1
-    def tree(self):
+    def tsk_tree(self):
         return tskit.Tree.generate_comb(5)
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 14
@@ -158,7 +175,7 @@ class TestMultiRootBinary:
     #     ┊ ┏┻┓ ┏┻┓ ┏┻┓ ┃ ┏┻┓ ┊
     # 0.00┊ 0 1 2 3 4 5 6 7 8 ┊
     #     0                   1
-    def tree(self):
+    def tsk_tree(self):
         tables = tskit.Tree.generate_balanced(9, arity=2).tree_sequence.dump_tables()
         edges = tables.edges.copy()
         tables.edges.clear()
@@ -166,6 +183,9 @@ class TestMultiRootBinary:
             if edge.parent != 16:
                 tables.edges.append(edge)
         return tables.tree_sequence().first()
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 20
@@ -183,9 +203,12 @@ class TestMultiRootBinary:
 
 
 class TestEmpty:
-    def tree(self):
+    def tsk_tree(self):
         tables = tskit.TableCollection(1)
         return tables.tree_sequence().first()
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 0
@@ -203,10 +226,13 @@ class TestEmpty:
 
 
 class TestTreeInNullState:
-    def tree(self):
+    def tsk_tree(self):
         tree = tskit.Tree.generate_comb(5)
         tree.clear()
         return tree
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 0
@@ -224,11 +250,14 @@ class TestTreeInNullState:
 
 
 class TestAllRootsN5:
-    def tree(self):
+    def tsk_tree(self):
         tables = tskit.TableCollection(1)
         for _ in range(5):
             tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, time=0)
         return tables.tree_sequence().first()
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
 
     def test_sackin(self):
         assert pk.sackin_index(self.tree()) == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,11 +7,11 @@ from phylokit import core
 class TestCreateTreeDataset:
     def test_single_node(self):
         ds = core.create_tree_dataset(
-            parent=[-1, -1],
-            time=[0, np.inf],
-            left_child=[-1, 0],
-            right_sib=[-1, -1],
-            samples=[0],
+            parent=np.array([-1, -1]),
+            time=np.array([0, np.inf]),
+            left_child=np.array([-1, 0]),
+            right_sib=np.array([-1, -1]),
+            samples=np.array([0]),
         )
         assert isinstance(ds, xarray.Dataset)
         assert ds.sizes[core.DIM_NODE] == 2

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -1,0 +1,203 @@
+import numpy as np
+import tskit
+
+import phylokit as pk
+
+
+class TestBalancedBinaryOdd:
+    # 2.00┊   4   ┊
+    #     ┊ ┏━┻┓  ┊
+    # 1.00┊ ┃  3  ┊
+    #     ┊ ┃ ┏┻┓ ┊
+    # 0.00┊ 0 1 2 ┊
+    #     0      1
+
+    def tsk_tree(self):
+        return tskit.Tree.generate_balanced(3)
+
+    def tree(self):
+        return pk.from_tskit(tskit.Tree.generate_balanced(3))
+
+    def test_postorder(self):
+        assert np.array_equal(pk.postorder(self.tree()), [0, 1, 2, 3, 4])
+
+    def test_preorder(self):
+        assert np.array_equal(pk.preorder(self.tree()), [4, 0, 3, 1, 2])
+
+    def test_postorder_from_node(self):
+        assert np.array_equal(pk.postorder(self.tree(), 3), [1, 2, 3])
+
+    def test_preorder_from_node(self):
+        assert np.array_equal(pk.preorder(self.tree(), 3), [3, 1, 2])
+
+
+class TestBalancedBinaryEven:
+    # 2.00┊    6    ┊
+    #     ┊  ┏━┻━┓  ┊
+    # 1.00┊  4   5  ┊
+    #     ┊ ┏┻┓ ┏┻┓ ┊
+    # 0.00┊ 0 1 2 3 ┊
+    #     0         1
+    def tsk_tree(self):
+        return tskit.Tree.generate_balanced(4)
+
+    def tree(self):
+        return pk.from_tskit(tskit.Tree.generate_balanced(4))
+
+    def test_postorder(self):
+        assert np.array_equal(pk.postorder(self.tree()), [0, 1, 4, 2, 3, 5, 6])
+
+    def test_preorder(self):
+        assert np.array_equal(pk.preorder(self.tree()), [6, 4, 0, 1, 5, 2, 3])
+
+
+class TestBalancedTernary:
+    # 2.00┊        12         ┊
+    #     ┊   ┏━━━━━╋━━━━━┓   ┊
+    # 1.00┊   9    10    11   ┊
+    #     ┊ ┏━╋━┓ ┏━╋━┓ ┏━╋━┓ ┊
+    # 0.00┊ 0 1 2 3 4 5 6 7 8 ┊
+    #     0                   1
+    def tsk_tree(self):
+        return tskit.Tree.generate_balanced(9, arity=3)
+
+    def tree(self):
+        return pk.from_tskit(tskit.Tree.generate_balanced(9, arity=3))
+
+    def test_postorder(self):
+        assert np.array_equal(
+            pk.postorder(self.tree()), [0, 1, 2, 9, 3, 4, 5, 10, 6, 7, 8, 11, 12]
+        )
+
+    def test_preorder(self):
+        assert np.array_equal(
+            pk.preorder(self.tree()), [12, 9, 0, 1, 2, 10, 3, 4, 5, 11, 6, 7, 8]
+        )
+
+
+class TestStarN10:
+    # 1.00┊         10          ┊
+    #     ┊ ┏━┳━┳━┳━┳┻┳━┳━┳━┳━┓ ┊
+    # 0.00┊ 0 1 2 3 4 5 6 7 8 9 ┊
+    #     0                     1
+    def tsk_tree(self):
+        return tskit.Tree.generate_star(10)
+
+    def tree(self):
+        return pk.from_tskit(tskit.Tree.generate_star(10))
+
+    def test_postorder(self):
+        assert np.array_equal(
+            pk.postorder(self.tree()), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        )
+
+    def test_preorder(self):
+        assert np.array_equal(
+            pk.preorder(self.tree()), [10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        )
+
+
+class TestCombN5:
+    # 4.00┊   8       ┊
+    #     ┊ ┏━┻━┓     ┊
+    # 3.00┊ ┃   7     ┊
+    #     ┊ ┃ ┏━┻━┓   ┊
+    # 2.00┊ ┃ ┃   6   ┊
+    #     ┊ ┃ ┃ ┏━┻┓  ┊
+    # 1.00┊ ┃ ┃ ┃  5  ┊
+    #     ┊ ┃ ┃ ┃ ┏┻┓ ┊
+    # 0.00┊ 0 1 2 3 4 ┊
+    #     0           1
+    def tsk_tree(self):
+        return tskit.Tree.generate_comb(5)
+
+    def tree(self):
+        return pk.from_tskit(tskit.Tree.generate_comb(5))
+
+    def test_postorder(self):
+        assert np.array_equal(pk.postorder(self.tree()), [0, 1, 2, 3, 4, 5, 6, 7, 8])
+
+    def test_preorder(self):
+        assert np.array_equal(pk.preorder(self.tree()), [8, 0, 7, 1, 6, 2, 5, 3, 4])
+
+
+class TestMultiRootBinary:
+    # 3.00┊            15     ┊
+    #     ┊          ┏━━┻━┓   ┊
+    # 2.00┊   11     ┃   14   ┊
+    #     ┊  ┏━┻━┓   ┃  ┏━┻┓  ┊
+    # 1.00┊  9  10  12  ┃ 13  ┊
+    #     ┊ ┏┻┓ ┏┻┓ ┏┻┓ ┃ ┏┻┓ ┊
+    # 0.00┊ 0 1 2 3 4 5 6 7 8 ┊
+    #     0                   1
+    def tsk_tree(self):
+        tables = tskit.Tree.generate_balanced(9, arity=2).tree_sequence.dump_tables()
+        edges = tables.edges.copy()
+        tables.edges.clear()
+        for edge in edges:
+            if edge.parent != 16:
+                tables.edges.append(edge)
+        return tables.tree_sequence().first()
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
+
+    def test_postorder(self):
+        assert np.array_equal(
+            pk.postorder(self.tree()),
+            [0, 1, 9, 2, 3, 10, 11, 4, 5, 12, 6, 7, 8, 13, 14, 15],
+        )
+
+    def test_preorder(self):
+        assert np.array_equal(
+            pk.preorder(self.tree()),
+            [11, 9, 0, 1, 10, 2, 3, 15, 12, 4, 5, 14, 6, 13, 7, 8],
+        )
+
+
+class TestEmpty:
+    def tsk_tree(self):
+        tables = tskit.TableCollection(1)
+        return tables.tree_sequence().first()
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
+
+    def test_postorder(self):
+        assert np.array_equal(pk.postorder(self.tree()), [])
+
+    def test_preorder(self):
+        assert np.array_equal(pk.preorder(self.tree()), [])
+
+
+class TestTreeInNullState:
+    def tsk_tree(self):
+        tree = tskit.Tree.generate_comb(5)
+        tree.clear()
+        return tree
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
+
+    def test_postorder(self):
+        assert np.array_equal(pk.postorder(self.tree()), [0, 1, 2, 3, 4])
+
+    def test_preorder(self):
+        assert np.array_equal(pk.preorder(self.tree()), [0, 1, 2, 3, 4])
+
+
+class TestAllRootsN5:
+    def tsk_tree(self):
+        tables = tskit.TableCollection(1)
+        for _ in range(5):
+            tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, time=0)
+        return tables.tree_sequence().first()
+
+    def tree(self):
+        return pk.from_tskit(self.tsk_tree())
+
+    def test_postorder(self):
+        assert np.array_equal(pk.postorder(self.tree()), [0, 1, 2, 3, 4])
+
+    def test_preorder(self):
+        assert np.array_equal(pk.preorder(self.tree()), [0, 1, 2, 3, 4])


### PR DESCRIPTION
**Tests**:
- [x] Update current tests with the new dataset interface. #14 

<del>

> Lots of them failed because of some default variable needed in the dataset.

</del>

**Core**:

- [x] Add `traversal_preorder` and `traversal_postorder` to `data_vars` when creating the dataset.

**Traversals**:
- [x] Preorder and Postorder Traversals. #18 
- [x] Inorder? (Don't know if we need this)

<del> 


</del>

**Distance**:

<del>

- [x] sv_mrca
> Here's a paper about it.
Schieber, B. and U. Vishkin (1988). "[On Finding Lowest Common Ancestors: Simplification and Parallelization.](https://epubs.siam.org/doi/10.1137/0217079)" SIAM Journal on Computing 17(6): 1253-1262.

</del>

> Will make `sv_mrca` in a separate PR.

**Convert**:
- [x] Add more defaults to `create_tree_dataset`. 

**Util**:
- [x] Move `is_unary()` function from `distance.py` to `util.py`.
- [x] Move `branch_length()` function from `distance.py` to `util.py`.
- [x] Add `get_node_branch_length()` function.
- [x] Add `get_num_roots()` function.