### PR TITLE
Add rf_distance function with tests for distance metrics

### DIFF
--- a/phylokit/__init__.py
+++ b/phylokit/__init__.py
@@ -8,6 +8,7 @@ from .convert import to_newick  # NOQA
 from .convert import to_tskit  # NOQA
 from .distance import kc_distance
 from .distance import mrca
+from .distance import rf_distance
 from .traversal import _postorder
 from .traversal import _preorder
 from .traversal import postorder
@@ -30,6 +31,7 @@ __all__ = [
     "mrca",
     "branch_length",
     "kc_distance",
+    "rf_distance",
     "postorder",
     "preorder",
     "_preorder",

--- a/requirements/CI.txt
+++ b/requirements/CI.txt
@@ -6,3 +6,4 @@ pytest-xdist==2.5.0
 tskit==0.5.0
 msprime==1.2.0
 sgkit==0.5.0
+dendropy==4.5.2


### PR DESCRIPTION
- [x] (UPDATED WITH THE NEW DATASET INTERFACE)

This is a naive implementation of the Robinson-Foulds distance between two trees. 

The slowest part is the set difference calculation when converting the NumPy array to Python tuples. 

- See #16 for more details