### PR TITLE
Likelihood Calculation Felsenstein

### DIFF
--- a/examples/likelihood.ipynb
+++ b/examples/likelihood.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "import msprime\n",
+    "import numpy as np\n",
+    "\n",
+    "# import local phylokit modules\n",
+    "phylokit_path = os.path.abspath(os.path.join(os.pardir))\n",
+    "if phylokit_path not in sys.path:\n",
+    "    sys.path.append(phylokit_path)\n",
+    "\n",
+    "import phylokit as pk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def simulate_ts(num_samples, sequence_length, mutation_rate, seed=1234):\n",
+    "    tsa = msprime.sim_ancestry(\n",
+    "        num_samples, sequence_length=sequence_length, ploidy=1, random_seed=seed\n",
+    "    )\n",
+    "    return msprime.sim_mutations(tsa, rate=mutation_rate, random_seed=seed)\n",
+    "\n",
+    "def create_mutation_tree(num_samples, sequence_length, mutation_rate, seed=1234):\n",
+    "    ts_in = simulate_ts(num_samples, sequence_length, mutation_rate, seed=seed)\n",
+    "    pk_mts = pk.parsimony.hartigan.ts_to_dataset(ts_in)\n",
+    "    ds_in = pk.from_tskit(ts_in.first())\n",
+    "    ds = ds_in.merge(pk_mts)\n",
+    "    return ds\n",
+    "\n",
+    "pk_mts = create_mutation_tree(10000, 1000, 0.001, seed=1234)\n",
+    "pk_mts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mutation_rate = 0.001\n",
+    "\n",
+    "pk.likelihood_felsenstein(pk_mts, rate=mutation_rate)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "phylokit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/phylokit/__init__.py
+++ b/phylokit/__init__.py
@@ -11,6 +11,7 @@ from .dataset import save_dataset
 from .distance import kc_distance
 from .distance import mrca
 from .distance import rf_distance
+from .maximum_likelihood.felsenstein import likelihood_felsenstein
 from .parsimony.hartigan import append_parsimony_score
 from .parsimony.hartigan import get_hartigan_parsimony_score
 from .parsimony.hartigan import numba_hartigan_parsimony_vectorised
@@ -53,4 +54,5 @@ __all__ = [
     "numba_hartigan_parsimony_vectorised",
     "get_hartigan_parsimony_score",
     "append_parsimony_score",
+    "likelihood_felsenstein",
 ]

--- a/phylokit/balance.py
+++ b/phylokit/balance.py
@@ -7,7 +7,7 @@ from . import jit
 from . import util
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _sackin_index(virtual_root, left_child, right_sib):
     stack = []
     root = left_child[virtual_root]
@@ -43,7 +43,7 @@ def sackin_index(ds):
     return _sackin_index(-1, ds.node_left_child.data, ds.node_right_sib.data)
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _colless_index(postorder, left_child, right_sib):
     num_leaves = np.zeros_like(left_child)
     total = 0.0
@@ -83,11 +83,13 @@ def colless_index(ds):
     if util.get_num_roots(ds) != 1:
         raise ValueError("Colless index not defined for multiroot trees")
     return _colless_index(
-        ds.traversal_postorder.data, ds.node_left_child.data, ds.node_right_sib.data
+        ds.traversal_postorder.data,
+        ds.node_left_child.data,
+        ds.node_right_sib.data,
     )
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _b1_index(postorder, left_child, right_sib, parent):
     max_path_length = np.zeros_like(postorder)
     total = 0.0
@@ -121,7 +123,7 @@ def b1_index(ds):
     )
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def general_log(x, base):
     """
     Compute the logarithm of x in base `base`.
@@ -134,7 +136,7 @@ def general_log(x, base):
     return math.log(x) / math.log(base)
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _b2_index(virtual_root, left_child, right_sib, base):
     root = left_child[virtual_root]
     stack = [(root, 1)]

--- a/phylokit/distance.py
+++ b/phylokit/distance.py
@@ -5,7 +5,7 @@ from . import jit
 from . import util
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _mrca(parent, time, u, v):
     tu = time[u]
     tv = time[v]
@@ -52,7 +52,7 @@ def mrca(ds, u, v):
         return _mrca(ds.node_parent.data, ds.node_time.data, u, v)
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _kc_distance(samples, ds1, ds2):
     # ds1 and ds2 are tuples of the form (parent_array, time_array, branch_length, root)
     n = samples.shape[0]

--- a/phylokit/inference.py
+++ b/phylokit/inference.py
@@ -7,7 +7,7 @@ from . import core
 from . import jit
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _linkage_matrix_to_dataset(Z):
     n = Z.shape[0] + 1
     N = 2 * n

--- a/phylokit/jit.py
+++ b/phylokit/jit.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 
@@ -30,8 +31,16 @@ DEFAULT_NUMBA_ARGS = {
 }
 
 
-def numba_njit(func, **kwargs):
-    if ENABLE_NUMBA:  # pragma: no cover
-        return numba.jit(func, **{**DEFAULT_NUMBA_ARGS, **kwargs})
-    else:
-        return func
+def numba_njit(**numba_kwargs):
+    def _numba_njit(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)  # pragma: no cover
+
+        if ENABLE_NUMBA:  # pragma: no cover
+            combined_kwargs = {**DEFAULT_NUMBA_ARGS, **numba_kwargs}
+            return numba.jit(**combined_kwargs)(func)
+        else:
+            return func
+
+    return _numba_njit

--- a/phylokit/maximum_likelihood/felsenstein.py
+++ b/phylokit/maximum_likelihood/felsenstein.py
@@ -1,0 +1,258 @@
+import numpy as np
+from numba import prange
+
+from .. import jit
+from .. import util
+
+
+@jit.numba_njit()
+def _transition_probability(i, j, t, mu, pi=None):
+    """
+    Transition probability from state i to j with branch length t
+    under the Jukes-Cantor model with mutation rate mu.
+
+    $P_{i j}(t)=e^{-u t} \\delta_{i j}+\\left(1-e^{-u t}\right) \\pi_j$
+
+    :param i: int, initial state
+    :param j: int, final state
+    :param t: float, branch length
+    :param mu: float, mutation rate
+    :param pi: np.array, transition probability matrix
+    with shape (4, 4)
+    :return: float, transition probability
+    """
+    delta_ij = 1.0 if i == j else 0.0
+    return np.exp(-mu * t) * delta_ij + (np.float64(1.0) - np.exp(-mu * t)) * pi[i][j]
+
+
+def _naive_calculate_likelihood(
+    node,
+    likelihood,
+    left_child,
+    right_sib,
+    node_branch_length,
+    rate,
+    pi,
+):
+    for start_state in range(4):
+        left_child_prob = 0
+        right_sib_prob = 0
+        for end_state in range(4):
+            left_child_prob += likelihood[left_child][
+                end_state
+            ] * _transition_probability(
+                start_state,
+                end_state,
+                node_branch_length[left_child],
+                rate,
+                pi,
+            )
+            right_sib_prob += likelihood[right_sib][
+                end_state
+            ] * _transition_probability(
+                start_state,
+                end_state,
+                node_branch_length[right_sib],
+                rate,
+                pi,
+            )
+        likelihood[node][start_state] = left_child_prob * right_sib_prob
+
+
+def _naive_likelihood_felsenstein(
+    node_left_child,
+    node_right_sib,
+    call_genotype,
+    num_nodes,
+    traversal_postorder,
+    sample_nodes,
+    variant_allele,
+    node_branch_length,
+    rate,
+    pi,
+):
+    ret = np.zeros(call_genotype.shape[0], dtype=np.float64)
+
+    for i in range(call_genotype.shape[0]):
+        likelihood = np.zeros((num_nodes, 4), dtype=np.float64)
+        for j, sample_node in enumerate(sample_nodes):
+            if call_genotype[i, j] == -1:
+                likelihood[sample_node] = 0.25
+            else:
+                likelihood[sample_node][variant_allele[i][call_genotype[i][j][0]]] = 1.0
+        for node in traversal_postorder:
+            if node in sample_nodes:
+                continue
+            else:
+                left_child = node_left_child[node]
+                right_sib = node_right_sib[left_child]
+                _naive_calculate_likelihood(
+                    node,
+                    likelihood,
+                    left_child,
+                    right_sib,
+                    node_branch_length,
+                    rate,
+                    pi,
+                )
+
+        ret[i] = np.sum(likelihood[traversal_postorder[-1]] * 0.25)
+
+    return ret
+
+
+def naive_likelihood_felsenstein(
+    ds,
+    rate,
+    pi=None,
+):
+    """
+    Basic implementation of the likelihood function for the
+    Felsenstein Likelihood calculation using the pruning algorithm.
+
+    :param ds: phylokit.DataSet, tree data
+    :param rate: float, mutation rate
+    :param GENOTYPE_ARRAY: list, genotype mapping,
+    :param pi: list, stationary distribution of states
+    :return: float, likelihood
+    """
+    GENOTYPE_ARRAY = np.array([b"A", b"C", b"G", b"T"], dtype="S")
+
+    if pi is None:
+        pi = np.full((4, 4), 0.25, dtype=np.float64)
+
+    likelihoods = _naive_likelihood_felsenstein(
+        ds.node_left_child.data,
+        ds.node_right_sib.data,
+        ds.call_genotype.data,
+        ds.nodes.shape[0],
+        ds.traversal_postorder.data,
+        ds.sample_node.data,
+        util.base_mapping(ds.variant_allele.data, GENOTYPE_ARRAY),
+        ds.node_branch_length.data,
+        rate,
+        pi,
+    )
+
+    ret = np.prod(likelihoods)
+
+    return ret
+
+
+@jit.numba_njit()
+def _calculate_likelihood(
+    child,
+    node_branch_length,
+    rate,
+    pi,
+    likelihood,
+):
+    probs = np.zeros(4, dtype=np.float64)
+    for start_state in range(4):
+        for end_state in range(4):
+            probs[start_state] += likelihood[
+                child, end_state
+            ] * _transition_probability(
+                start_state,
+                end_state,
+                node_branch_length[child],
+                rate,
+                pi,
+            )
+    return probs
+
+
+@jit.numba_njit(parallel=True)
+def _likelihood_felsenstein(
+    node_left_child,
+    node_right_sib,
+    call_genotype,
+    num_nodes,
+    traversal_postorder,
+    sample_nodes,
+    variant_allele,
+    node_branch_length,
+    rate,
+    pi,
+):
+    ret = np.zeros(call_genotype.shape[0], dtype=np.float64)
+
+    sample_mask = np.zeros(num_nodes, dtype=np.bool_)
+    sample_mask[sample_nodes] = True
+
+    for i in prange(call_genotype.shape[0]):
+        likelihood = np.zeros((num_nodes, 4), dtype=np.float64)
+        for j, sample_node in enumerate(sample_nodes):
+            if call_genotype[i, j] == -1:
+                likelihood[sample_node] = 0.25
+            else:
+                likelihood[sample_node, variant_allele[i, call_genotype[i, j, 0]]] = 1.0
+        for node in traversal_postorder:
+            if sample_mask[node]:
+                continue
+            else:
+                u = node_left_child[node]
+                probs = _calculate_likelihood(
+                    u,
+                    node_branch_length,
+                    rate,
+                    pi,
+                    likelihood,
+                )
+                v = node_right_sib[u]
+                while v != -1:
+                    probs *= _calculate_likelihood(
+                        v,
+                        node_branch_length,
+                        rate,
+                        pi,
+                        likelihood,
+                    )
+                    v = node_right_sib[v]
+
+                likelihood[node] = probs
+
+        ret[i] = np.sum(likelihood[traversal_postorder[-1]] * 0.25)
+
+    return np.prod(ret)
+
+
+def likelihood_felsenstein(
+    ds,
+    rate,
+    pi=None,
+):
+    """
+    Calculate the likelihood of a given tree with `Felsenstein`
+    pruning algorithm. This implementation is a parallelized
+    version of the `naive_likelihood_felsenstein` function.
+
+    :param ds: phylokit.DataSet, tree data
+    :param rate: float, mutation rate
+    :param pi: np.array, transtion probability matrix with
+    shape (4, 4),
+    default is [0.25, 0.25, 0.25, 0.25]
+    :return: float, likelihood
+    """
+
+    GENOTYPE_ARRAY = np.array([b"A", b"C", b"G", b"T"], dtype="S")
+
+    if pi is None:
+        pi = np.full((4, 4), 0.25, dtype=np.float64)
+    elif pi.shape != (4, 4):
+        raise ValueError("The transition probability matrix must have shape (4, 4)")
+
+    ret = _likelihood_felsenstein(
+        ds.node_left_child.data,
+        ds.node_right_sib.data,
+        ds.call_genotype.data,
+        ds.nodes.shape[0],
+        ds.traversal_postorder.data,
+        ds.sample_node.data,
+        util.base_mapping(ds.variant_allele.data, GENOTYPE_ARRAY),
+        ds.node_branch_length.data,
+        rate,
+        pi,
+    )
+
+    return ret

--- a/phylokit/transform.py
+++ b/phylokit/transform.py
@@ -5,7 +5,7 @@ from . import jit
 from . import util
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _permute_node_seq(nodes, ordering, reversed_map):
     ret = np.zeros_like(nodes, dtype=np.int32)
     for u, v in enumerate(ordering):

--- a/phylokit/traversal.py
+++ b/phylokit/traversal.py
@@ -3,7 +3,7 @@ import numpy as np
 from . import jit
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _postorder(left_child, right_sib, root):
     # Another implementation with python stack operations such as `pop`
     # makes the same function about 2X slower.
@@ -59,7 +59,7 @@ def postorder(ds, root=None):
     )
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _preorder(parent, left_child, right_sib, root):
     # Another implementation with python stack operations such as `pop`
     # makes the same function about 2X slower.

--- a/phylokit/util.py
+++ b/phylokit/util.py
@@ -88,7 +88,7 @@ def branch_length(ds, u):
 
 @jit.numba_njit
 def _get_node_branch_length(parent, time):
-    ret = np.zeros_like(parent)
+    ret = np.zeros_like(parent, dtype=np.float64)
     for i in range(parent.shape[0]):
         ret[i] = _branch_length(parent, time, i)
     return ret

--- a/phylokit/util.py
+++ b/phylokit/util.py
@@ -4,7 +4,7 @@ from numba import prange
 from . import jit
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _is_unary(postorder, left_child, right_sib):
     for u in postorder:
         v = left_child[u]
@@ -45,7 +45,7 @@ def check_node_bounds(ds, *args):
             raise ValueError(f"Node {u} is not in the tree")
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _get_num_roots(left_child, right_sib):
     u = left_child[-1]
     num_roots = 0
@@ -66,7 +66,7 @@ def get_num_roots(ds):
     return _get_num_roots(ds.node_left_child.data, ds.node_right_sib.data)
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _branch_length(parent, time, u):
     ret = 0
     p = parent[u]
@@ -89,7 +89,7 @@ def branch_length(ds, u):
     return _branch_length(ds.node_parent.data, ds.node_time.data, u)
 
 
-@jit.numba_njit
+@jit.numba_njit()
 def _get_node_branch_length(parent, time):
     ret = np.zeros_like(parent, dtype=np.float64)
     for i in range(parent.shape[0]):
@@ -132,6 +132,3 @@ def base_mapping(base_matrix, mapper_matrix):
                 result_matrix[i] = j
                 break
     return result_matrix.reshape(base_shape)
-
-
-base_mapping = jit.numba_njit(base_mapping, parallel=True)

--- a/phylokit/util.py
+++ b/phylokit/util.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numba import prange
 
 from . import jit
 
@@ -24,7 +25,9 @@ def is_unary(ds):
     :rtype : bool
     """
     return _is_unary(
-        ds.traversal_postorder.data, ds.node_left_child.data, ds.node_right_sib.data
+        ds.traversal_postorder.data,
+        ds.node_left_child.data,
+        ds.node_right_sib.data,
     )
 
 
@@ -103,3 +106,32 @@ def get_node_branch_length(ds):
     :rtype: numpy.ndarray
     """
     return _get_node_branch_length(ds.node_parent.data, ds.node_time.data)
+
+
+@jit.numba_njit(parallel=True)
+def base_mapping(base_matrix, mapper_matrix):
+    """
+    Convert the base matrix with the mapper matrix.
+
+    For example:
+        base_matrix = [[b'A', b'C'], [b'C', b'G']]
+        mapper_matrix = [b'A', b'C', b'G', b'T']
+
+        result_matrix = [[0, 1], [1, 2]]
+
+    :param numpy.ndarray base_matrix: The base matrix to convert.
+    :param numpy.ndarray mapping_matrix: The mapping matrix.
+    :return: The converted matrix.
+    """
+    base_shape = base_matrix.shape
+    base_matrix = base_matrix.flatten()
+    result_matrix = np.zeros_like(base_matrix, dtype=np.int8)
+    for i in prange(base_matrix.shape[0]):
+        for j in range(mapper_matrix.shape[0]):
+            if base_matrix[i] == mapper_matrix[j]:
+                result_matrix[i] = j
+                break
+    return result_matrix.reshape(base_shape)
+
+
+base_mapping = jit.numba_njit(base_mapping, parallel=True)

--- a/tests/test_felsenstein.py
+++ b/tests/test_felsenstein.py
@@ -1,0 +1,174 @@
+import msprime
+import numpy as np
+import pytest
+import sgkit
+
+import phylokit as pk
+from phylokit.maximum_likelihood import felsenstein
+
+
+class TestFelsensteinML:
+
+    def ts_to_dataset(self, ts, samples=None):
+        """
+        Convert the specified tskit tree sequence into an sgkit dataset.
+        Note this just generates haploids for now - see the note above
+        in simulate_ts.
+        """
+        if samples is None:
+            samples = ts.samples()
+        tables = ts.dump_tables()
+        alleles = []
+        genotypes = []
+        max_alleles = 0
+        for var in ts.variants(samples=samples):
+            alleles.append(var.alleles)
+            max_alleles = max(max_alleles, len(var.alleles))
+            genotypes.append(var.genotypes)
+        padded_alleles = [
+            list(site_alleles) + [""] * (max_alleles - len(site_alleles))
+            for site_alleles in alleles
+        ]
+        alleles = np.array(padded_alleles).astype("S")
+        genotypes = np.expand_dims(genotypes, axis=2)
+
+        ds = sgkit.create_genotype_call_dataset(
+            variant_contig_names=["1"],
+            variant_contig=np.zeros(len(tables.sites), dtype=int),
+            variant_position=tables.sites.position.astype(int),
+            variant_allele=alleles,
+            sample_id=np.array([f"tsk_{u}" for u in samples]).astype("U"),
+            call_genotype=genotypes,
+        )
+        return ds
+
+    def simulate_ts(self, num_samples, sequence_length, mutation_rate, seed=1234):
+        tsa = msprime.sim_ancestry(
+            num_samples,
+            recombination_rate=0,
+            sequence_length=sequence_length,
+            ploidy=1,
+            random_seed=seed,
+        )
+        return msprime.sim_mutations(tsa, mutation_rate, random_seed=seed)
+
+    def create_mutation_tree(self, ts_in):
+        pk_mts = self.ts_to_dataset(ts_in)
+        ds_in = pk.from_tskit(ts_in.first())
+        ds = ds_in.merge(pk_mts)
+        return ds
+
+    def test_same_base_transition_probability(self):
+        assert felsenstein._transition_probability(
+            0, 0, 1, 1, np.full((4, 4), 0.25, dtype=np.float64)
+        ) == pytest.approx(0.5259095808785818)
+
+    def test_diff_base_transition_probability(self):
+        assert felsenstein._transition_probability(
+            0, 1, 1, 1, np.full((4, 4), 0.25, dtype=np.float64)
+        ) == pytest.approx(0.15803013970713942)
+
+    def test_naive_calculate_likelihood(self):
+
+        likelihood = np.array(
+            [[1, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0]], dtype=np.float64
+        )
+        node_branch_length = np.array([0.035433, 0.035433, 0.0], dtype=np.float64)
+        pi = np.full((4, 4), 0.25, dtype=np.float64)
+
+        felsenstein._naive_calculate_likelihood(
+            2, likelihood, 0, 1, node_branch_length, 0.005, pi
+        )
+
+        assert np.allclose(
+            np.array(
+                [
+                    0.9997342928667493,
+                    1.961379492146412e-09,
+                    1.961379492146412e-09,
+                    1.961379492146412e-09,
+                ],
+                dtype=np.float64,
+            ),
+            likelihood[2],
+        )
+
+    def test_felsenstein_likelihood(self):
+        """
+        This test is manually calculated from the tree below
+               6
+             ┏━┻━┓
+             5   ┃
+            ┏┻┓  ┃
+            ┃ ┃  4
+            ┃ ┃ ┏┻┓
+            0 3 1 2
+
+        Likelihoods:
+            0.0011235557375395503,
+            0.0011235557375395503,
+            0.00018600192239752195,
+            0.0011235557375395503,
+        for each variant.
+        """
+        msprime_tree = self.simulate_ts(4, 100, 0.005, seed=1234)
+        pk_mts = self.create_mutation_tree(msprime_tree)
+
+        assert np.log(
+            felsenstein.likelihood_felsenstein(pk_mts, 0.005)
+        ) == pytest.approx(-28.963524119660995)
+
+    def test_felsenstein_likelihood_no_data(self):
+        """
+        This test is manually calculated from the tree below
+               6
+             ┏━┻━┓
+             5   ┃
+            ┏┻┓  ┃
+            ┃ ┃  4
+            ┃ ┃ ┏┻┓
+            0 3 1 2
+
+        With the first variant at sample 0 having no data.
+        which gives the sample 0 with a equal probability
+        of 0.25 for each base
+
+        Likelihoods:
+            0.00032830706033402403,
+            0.0011235557375395503,
+            0.00018600192239752195,
+            0.0011235557375395503,
+        for each variant.
+        """
+        msprime_tree = self.simulate_ts(4, 100, 0.005, seed=1234)
+        pk_mts = self.create_mutation_tree(msprime_tree)
+
+        # Set the first variant at sample 0 to have no data
+        pk_mts.call_genotype[0][0][0] = -1
+
+        assert np.log(
+            felsenstein.naive_likelihood_felsenstein(pk_mts, 0.005)
+        ) == pytest.approx(-30.193828490667887)
+
+        assert np.log(
+            felsenstein.likelihood_felsenstein(pk_mts, 0.005)
+        ) == pytest.approx(-30.193828490667887)
+
+    @pytest.mark.parametrize("mutation_rate", [0.01, 0.02, 0.03])
+    def test_felsenstein(self, mutation_rate):
+        msprime_tree = self.simulate_ts(100, 100, mutation_rate, seed=1234)
+        pk_tree = self.create_mutation_tree(msprime_tree)
+        assert felsenstein.naive_likelihood_felsenstein(
+            pk_tree, mutation_rate
+        ) == pytest.approx(felsenstein.likelihood_felsenstein(pk_tree, mutation_rate))
+
+    def test_felsenstein_error(self):
+        msprime_tree = self.simulate_ts(100, 100, 0.01, seed=1234)
+        pk_tree = self.create_mutation_tree(msprime_tree)
+
+        with pytest.raises(ValueError):
+            felsenstein.likelihood_felsenstein(
+                pk_tree,
+                0.01,
+                np.full((4, 3), 0.25, dtype=np.float64),
+            )


### PR DESCRIPTION
## Likelihood Calculation

This PR introduces a set of functions for computing the likelihood of phylogenetic trees.

### Checklist
- [x] Implement the basic version of `Felsenstein`'s likelihood calculation.
- [x] Implement `_get_genotype_index` to find genotype indices in a mapping array.
- [x] Implement `_transition_probability` for calculating mutation transition probabilities.
- [x] Implement `_calculate_likelihood` to compute likelihoods using the transition probabilities.
- [x] Create `likelihood_felsenstein` as the high-level function orchestrating the likelihood computation.
- [ ] Implement a `variant` vectorised version of likelihood calculation function. 
- [x] Implement unit tests for all new functions.
- [x] Add documentation and examples for new functions.

### Notes
- The implementation uses Numba `parallel=True` option in `_likelihood_felsenstein`.